### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,6 @@
+buildPlugin(
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.538</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>4.51</version>
+    <relativePath />
   </parent>
 
   <artifactId>ec2-cloud-axis</artifactId>
@@ -26,60 +27,62 @@
   </pluginRepositories>
 
   <properties>
-    <!--
-      explicitly specifying the latest version here because one we get from the parent POM
-      tends to lag behind a bit
-    -->
-    <maven-hpi-plugin.version>1.95</maven-hpi-plugin.version>
+    <jenkins.version>2.346.3</jenkins.version>
+    <bc-version>1.72</bc-version>
   </properties>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.jenkins-ci.plugins</groupId>
-			<artifactId>ec2</artifactId>
-			<version>1.19</version>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.9.5</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.1</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+  <dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.jenkins.tools.bom</groupId>
+            <artifactId>bom-2.346.x</artifactId>
+            <version>1750.v0071fa_4c4a_e3</version>
+            <scope>import</scope>
+            <type>pom</type>
+        </dependency>
+    </dependencies>
+  </dependencyManagement>
 
-  <build>
-      <plugins>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-            <encoding>UTF8</encoding>
-          </configuration>
-        </plugin>
-      </plugins>
-  </build>  
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ec2</artifactId>
+      <version>1.19</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>trilead-api</artifactId>
+      <exclusions>
+        <exclusion>
+	  <groupId>org.json</groupId>
+	  <artifactId>json</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <version>${bc-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>${bc-version}</version>
+    </dependency>
+  </dependencies>
+
   <scm>
-    <connection>scm:git:ssh://github.com/jenkinsci/ec2-cloud-axis-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/ec2-cloud-axis-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com:jenkinsci/ec2-cloud-axis-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/ec2-cloud-axis-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/ec2-cloud-axis-plugin</url>
   </scm>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/EC2+Cloud+Axis</url>

--- a/src/main/java/hudson/plugins/ec2/BuildStartEndListener.java
+++ b/src/main/java/hudson/plugins/ec2/BuildStartEndListener.java
@@ -1,5 +1,7 @@
 package hudson.plugins.ec2;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
@@ -9,6 +11,8 @@ import org.apache.commons.io.output.NullOutputStream;
 import hudson.console.ConsoleNote;
 import hudson.model.BuildListener;
 
+@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING",
+                    justification = "Encoding to null output stream is not a problem")
 @SuppressWarnings("serial")
 public abstract class BuildStartEndListener implements BuildListener {
 	private static PrintStream nullOutputStream = new PrintStream(new NullOutputStream());

--- a/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
@@ -177,6 +177,10 @@ public class EC2AxisCloud extends AmazonEC2Cloud {
 		logger.println("Will check " + ec2Label);
 		
 		Label label = Jenkins.getInstance().getLabel(getAxisLabel(ec2Label));
+		if (label == null) {
+			logger.println("Null label for " + ec2Label);
+			return onlineAndAvailableLabels;
+		}
 		
 		for (Node node : label.getNodes()) {
 			if(!isNodeAvailable(logger, node)) 
@@ -214,7 +218,7 @@ public class EC2AxisCloud extends AmazonEC2Cloud {
 		String nodeName = node.getDisplayName();
 		logger.println("Checking node : " + nodeName);
 		Computer c = node.toComputer();
-		if (c.isOffline() || c.isConnecting()) 
+		if (c == null || c.isOffline() || c.isConnecting())
 			return false;
 		if (isNodeOnlineAndAvailable(c) && hasAvailableExecutor(c))
 			return true;

--- a/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
@@ -10,10 +10,10 @@ import hudson.model.Node;
 import hudson.model.labels.LabelAtom;
 import hudson.slaves.Cloud;
 import hudson.slaves.EnvironmentVariablesNodeProperty;
-import hudson.util.TimeUnit2;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -265,8 +265,7 @@ public class EC2AxisCloud extends AmazonEC2Cloud {
 
 	public static long getTimeout(EC2AbstractSlave slave) {
 		if (slave.getLaunchTimeoutInMillis() == 0)
-			return TimeUnit2.MINUTES.toMillis(20);
+			return TimeUnit.MINUTES.toMillis(20);
 		return slave.getLaunchTimeoutInMillis();
 	}
 }
- 

--- a/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
+++ b/src/main/java/hudson/plugins/ec2/EC2AxisCloud.java
@@ -50,8 +50,6 @@ public class EC2AxisCloud extends AmazonEC2Cloud {
 	@Override
 	public Ec2AxisSlaveTemplate getTemplate(Label label) {
 		String displayName = label.getDisplayName();
-		if (displayName == null)
-			return null;
 		
     	String labelPrefix = StringUtils.substringBefore(displayName,SLAVE_NUM_SEPARATOR);
 		LabelAtom prefixAtom = new LabelAtom(labelPrefix);
@@ -205,8 +203,6 @@ public class EC2AxisCloud extends AmazonEC2Cloud {
 
 	private Ec2AxisSlaveTemplate getTemplateGivenLabel(Label label) {
 		String displayName = label.getDisplayName();
-		if (displayName == null)
-			return null;
 		
     	String labelPrefix = StringUtils.substringBefore(displayName,SLAVE_NUM_SEPARATOR);
 		LabelAtom prefixAtom = new LabelAtom(labelPrefix);

--- a/src/main/java/hudson/plugins/ec2/OnDemandSlaveLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/OnDemandSlaveLauncher.java
@@ -29,7 +29,12 @@ final class OnDemandSlaveLauncher implements Runnable {
 		Future<?> connectionPromise;
 		String displayName = slave.getDisplayName();
 		do {
-			connectionPromise = slave.toComputer().connect(false);
+                        hudson.model.Computer computer = slave.toComputer();
+                        if (computer == null) {
+				logger.println("No node for " + displayName);
+				return;
+                        }
+			connectionPromise = computer.connect(false);
 			if (waitForConnection(connectionPromise))
 				return;
 			try {

--- a/src/main/java/hudson/plugins/ec2/OnDemandSlaveLauncher.java
+++ b/src/main/java/hudson/plugins/ec2/OnDemandSlaveLauncher.java
@@ -1,9 +1,8 @@
 package hudson.plugins.ec2;
 
-import hudson.util.TimeUnit2;
-
 import java.util.List;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.time.StopWatch;
 
@@ -22,7 +21,7 @@ final class OnDemandSlaveLauncher implements Runnable {
 	public void run() {
 		long timeout = EC2AxisCloud.getTimeout(slave);
 		int retryIntervalSecs = 5;
-		long retryIntervalMillis = TimeUnit2.SECONDS.toMillis(retryIntervalSecs);
+		long retryIntervalMillis = TimeUnit.SECONDS.toMillis(retryIntervalSecs);
 		long maxWait = System.currentTimeMillis() + timeout;
 		StopWatch stopwatch = new StopWatch();
 		stopwatch.start();

--- a/src/main/java/hudson/plugins/ec2/SpotRequestConnectSupervisor.java
+++ b/src/main/java/hudson/plugins/ec2/SpotRequestConnectSupervisor.java
@@ -195,7 +195,7 @@ final class SpotRequestConnectSupervisor implements Runnable {
 					startSlaveAgentOnRemoteInstance(slaveToAssociate, jenkinsUrl, sshConnection);
 					logger.println("Successfully connected to "+privateIpAddress);
 					return true; 
-				}catch(Exception e) {
+				} catch (IOException | InterruptedException e) {
 					return false;
 				}
 			}
@@ -204,7 +204,7 @@ final class SpotRequestConnectSupervisor implements Runnable {
 				logger.println(message);
 				throw new RuntimeException(message);
 			}
-		}catch(Exception e) {
+		} catch (IOException e) {
 			return false;
 		}
 	}

--- a/src/main/java/hudson/plugins/ec2/SpotRequestConnectSupervisor.java
+++ b/src/main/java/hudson/plugins/ec2/SpotRequestConnectSupervisor.java
@@ -1,12 +1,12 @@
 package hudson.plugins.ec2;
 
 import hudson.model.Hudson;
-import hudson.util.TimeUnit2;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.StopWatch;
@@ -150,7 +150,7 @@ final class SpotRequestConnectSupervisor implements Runnable {
 		boolean success;
 		long timeout = EC2AxisCloud.getTimeout(slaveToAssociate);
 		int retryIntervalSecs = 5;
-		long retryIntervalMillis = TimeUnit2.SECONDS.toMillis(retryIntervalSecs);
+		long retryIntervalMillis = TimeUnit.SECONDS.toMillis(retryIntervalSecs);
 		long maxWait = System.currentTimeMillis() + timeout;
 		StopWatch stopwatch = new StopWatch();
 		stopwatch.start();
@@ -222,7 +222,7 @@ final class SpotRequestConnectSupervisor implements Runnable {
 	}
 
 	private void execCommandAndWaitForCompletion(Session openSession, String cmd) throws IOException, InterruptedException {
-		long timeoutForCommand = TimeUnit2.MINUTES.toMillis(5);
+		long timeoutForCommand = TimeUnit.MINUTES.toMillis(5);
 		openSession.execCommand(cmd);
 		openSession.waitForCondition(ChannelCondition.EXIT_STATUS, timeoutForCommand);
 		Integer exitStatus = openSession.getExitStatus();

--- a/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
+++ b/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
@@ -18,6 +18,7 @@ import hudson.plugins.ec2.EC2AxisCloud;
 import hudson.plugins.ec2.EC2Logger;
 import hudson.util.FormValidation;
 
+import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -254,10 +255,10 @@ public class EC2Axis extends LabelAxis {
 				for (LabelAtom a : l.listAtoms()) {
 					if (a.isEmpty()) {
 						LabelAtom nearest = LabelAtom.findNearest(a.getName());
-						return FormValidation.warning(Messages.AbstractProject_AssignedLabelString_NoMatch_DidYouMean(a.getName(),nearest.getDisplayName()));
+						return FormValidation.warning(MessageFormat.format("No agent/cloud matches this label expression. Did you mean ‘{1}’ instead of ‘{0}’?", a.getName(), nearest.getDisplayName()));
 					}
 				}
-				return FormValidation.warning(Messages.AbstractProject_AssignedLabelString_NoMatch());
+				return FormValidation.warning("No agent/cloud matches this label expression.");
 			}
 			return FormValidation.ok();
 		}

--- a/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
+++ b/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
@@ -22,6 +22,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -215,6 +216,27 @@ public class EC2Axis extends LabelAxis {
 	public void setCreateMatrixEnvironmentVariable(
 			boolean createMatrixEnvironmentVariable) {
 		this.createMatrixEnvironmentVariable = createMatrixEnvironmentVariable;
+	}
+
+	public int hashCode() {
+                return Objects.hash(name, ec2label, numberOfSlaves, instanceBootTimeoutLimit, createMatrixEnvironmentVariable);
+	}
+
+	public boolean equals(Object obj) {
+            if (obj == null) {
+                return false;
+            }
+            if (obj.getClass() != this.getClass()) {
+                return false;
+            }
+            EC2Axis other = (EC2Axis) obj;
+            return
+                Objects.equals(other.name, this.name) &&
+                Objects.equals(other.ec2label, this.ec2label) &&
+                Objects.equals(other.numberOfSlaves, this.numberOfSlaves) &&
+                Objects.equals(other.alwaysCreateNewNodes, this.alwaysCreateNewNodes) &&
+                Objects.equals(other.instanceBootTimeoutLimit, this.instanceBootTimeoutLimit) &&
+                Objects.equals(other.createMatrixEnvironmentVariable, this.createMatrixEnvironmentVariable);
 	}
 
 	@Extension

--- a/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
+++ b/src/main/java/org/jenkinsci/plugins/ec2axis/EC2Axis.java
@@ -251,6 +251,9 @@ public class EC2Axis extends LabelAxis {
 				return FormValidation.ok(); 
 			
 			Label l = Jenkins.getInstance().getLabel(oneLabel);
+                        if (l == null) {
+				return FormValidation.warning("No agent/cloud matches this label expression.");
+                        }
 			if (l.isEmpty()) {
 				for (LabelAtom a : l.listAtoms()) {
 					if (a.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/ec2axis/Ec2SafeNodeTaskWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/ec2axis/Ec2SafeNodeTaskWorker.java
@@ -2,12 +2,12 @@ package org.jenkinsci.plugins.ec2axis;
 
 import hudson.Extension;
 import hudson.model.PeriodicWork;
-import hudson.util.TimeUnit2;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 @Extension
 public class Ec2SafeNodeTaskWorker extends PeriodicWork {
@@ -24,7 +24,7 @@ public class Ec2SafeNodeTaskWorker extends PeriodicWork {
 
 	@Override
 	public long getRecurrencePeriod() {
-		return TimeUnit2.SECONDS.toMillis(1);
+		return TimeUnit.SECONDS.toMillis(1);
 	}
 
 	@Override

--- a/src/main/java/org/jenkinsci/plugins/ec2axis/Ec2SafeNodeTaskWorker.java
+++ b/src/main/java/org/jenkinsci/plugins/ec2axis/Ec2SafeNodeTaskWorker.java
@@ -8,11 +8,14 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Extension
 public class Ec2SafeNodeTaskWorker extends PeriodicWork {
 	private static BlockingQueue<FutureTask<Void>> tasks = new LinkedBlockingQueue<>();
-	
+        private static final Logger LOGGER = Logger.getLogger(Ec2SafeNodeTaskWorker.class.getName());
+
 	public static void invokeAndWait(final Runnable task) {
 		FutureTask<Void> futureTask = invoke(task);
 		try {
@@ -39,7 +42,10 @@ public class Ec2SafeNodeTaskWorker extends PeriodicWork {
 
 	public static FutureTask<Void> invoke(final Runnable task) {
 		FutureTask<Void> futureTask = new FutureTask<>(task, null);
-		tasks.offer(futureTask);
+		boolean inserted = tasks.offer(futureTask);
+                if (!inserted) {
+                    LOGGER.log(Level.FINE, "Failed to insert task {0} into queue", futureTask.toString());
+                }
 		return futureTask;
 	}
 		

--- a/src/main/resources/hudson/plugins/ec2/Ec2AxisSlaveTemplate/config.jelly
+++ b/src/main/resources/hudson/plugins/ec2/Ec2AxisSlaveTemplate/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" >
   <table width="100%">
 

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   Adds an axis for matrix builds to run over an arbitrary number of EC2 instances, which will be dinamically allocated or reused if possible.
   Requires the EC2 plugin.

--- a/src/main/resources/org/jenkinsci/plugins/ec2axis/Ec2AxisDescriptionAction/summary.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ec2axis/Ec2AxisDescriptionAction/summary.jelly
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
-
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 <j:if test="${it.iconPath != null}">
   <t:summary icon="${it.iconPath}">


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

Also includes modernization changes to use a recent parent pom and resolve or suppress spotbugs warnings.

- Add Jenkinsfile for ci.jenkins.io
- Escape jelly files as required by modern tooling
- Replace TimeUnit2 with TimeUnit
- Use local message instead of message from core
- Do not ignore return value of offer()
- Check getLabel() return value for null
- Implement equals and hashCode in EC2Axis
- Catch more specific exceptions
- Guard OnDemandSlaveLauncher from NPE
- Use UTF-8 encoding to read data bytes
- Remove redundant null check from EC2AxisCloud
- Avoid NPE in EC2AxisCloud
- Suppress encoding warning for null output stream
- Require Jenkins 2.346.3 or newer

Does not update to require Java 11.  That can be done in a future step.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
