### PR TITLE
Require Jenkins 2.361.4 or newer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 
@@ -27,15 +27,15 @@
   </pluginRepositories>
 
   <properties>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.jenkins.tools.bom</groupId>
-            <artifactId>bom-2.346.x</artifactId>
-            <version>1763.v092b_8980a_f5e</version>
+            <artifactId>bom-2.361.x</artifactId>
+            <version>2102.v854b_fec19c92</version>
             <scope>import</scope>
             <type>pom</type>
         </dependency>


### PR DESCRIPTION
## Require Jenkins 2.361.4 or newer

Plugin still fails to compile if a newer release of the EC2 plugin is declared as a dependency.  API changes in the EC2 plugin will require changes in this plugin if it is to be released in the future.

### Testing done

Confirmed that automated tests pass.  No interactive testing performed.  There is reasonable suspicion that the plugin won't work with recent releases of the EC2 plugin.  Fixing the build so that the plugin compiles and passes its automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
